### PR TITLE
🔧 Ensure post is a model instance before calling handlePreview

### DIFF
--- a/app/Livewire/Post/Show.php
+++ b/app/Livewire/Post/Show.php
@@ -26,15 +26,11 @@ class Show extends Component
      */
     public function mount($post)
     {
-        $this->post = Post::whereSlug($post);
+        $this->post = Post::whereSlug($post)->firstOrFail();
 
         $this->handlePreview();
 
-        if (! $this->isPreview) {
-            $this->post = $this->post->published();
-        }
-
-        $this->post = $this->post->firstOrFail();
+        abort_unless($this->isPreview || $this->post->is_published, 404);
     }
 
     /**


### PR DESCRIPTION
It seems like calling `handlePreview()` after `Post::whereSlug()` operates on a `Builder` instance instead of a model, so the unsaved preview data is later discarded with the call to `firstOrFail()`.

Not sure if I'm explaining well, let me know if I'm missing something obvious :)