### PR TITLE
Locking the laravel Framework version to 11.27.2 temporarily

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "diglactic/laravel-breadcrumbs": "^9.0",
     "filament/filament": "^3.2.50",
     "jeffgreco13/filament-breezy": "^2.2",
-    "laravel/framework": "^11.0",
+    "laravel/framework": "11.27.2",
     "laravel/sanctum": "^4.0",
     "laravel/tinker": "^2.9",
     "livewire/livewire": "^3.3",


### PR DESCRIPTION
A fresh installation of the project was showing a lot of errors in the console and by talking with Brandon found out that locking the Laravel framework version to 11.27.2 tempoararily fixed the issue.

Possible cause of error is some upstream issue with newer framework version.

Locking the framework version to 11.27.2 has resolved the issue so we can keep this temporarily in composer.json until newer laravel framework versions fixes this issue.

<img width="1208" alt="Screenshot 2024-10-17 at 9 41 49 am" src="https://github.com/user-attachments/assets/29392c8c-c2e7-408b-911a-4ed1413fcabd">
.

